### PR TITLE
Fixes enabling build with <toolset>msvc 

### DIFF
--- a/Jamroot
+++ b/Jamroot
@@ -18,6 +18,7 @@ if $(BOOST_ROOT)
 project
    : requirements
       <toolset>gcc:<cxxflags>-ftemplate-depth=300
+      <toolset>msvc:<cxxflags>/wd4996
    ;
 
 lib json


### PR DESCRIPTION
This pull requests delivers a bunch of fixes that enable build with Visual C++ (I use Visual Studio 2012).
- Generate static library for <toolset>msvc as the library does not dllexport anything (yet?)
- Disable warning C4996
