### PR TITLE
Add fuzzing infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ else()
   find_package( Boost COMPONENTS unit_test_framework REQUIRED )
 endif()
 
-include_directories( . ${Boost_INCLUDE_DIRS} )
+include_directories( . )
+include_directories( SYSTEM ${Boost_INCLUDE_DIRS} )
 
 file( GLOB SRC_FILES libs/json/src/*.cpp )
 add_library( json STATIC ${SRC_FILES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Main CMake build control file for json_spirit
-# Copyright (C) 2013 Jeff Trull <edaskel@att.net>
+# Copyright (C) 2013,2015 Jeff Trull <edaskel@att.net>
 #
 #   Distributed under the Boost Software License, Version 1.0. (See accompanying
 #   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,6 +13,9 @@ cmake_minimum_required( VERSION 2.8.11 )
 project( json_spirit )
 
 option(JSON_SPIRIT_DEBUG_PARSER "Trace spirit parser in Debug config" OFF)
+
+option(JSON_SPIRIT_FUZZING "Enable build of fuzzing targets" OFF)
+set( SANITIZER address )    # "memory" is the other supported (but probably buggy) option
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   add_definitions( -std=c++11 )
@@ -31,11 +34,70 @@ endif()
 # compilers.
 add_definitions( -DBOOST_SPIRIT_USE_PHOENIX_V3=1 )
 
-find_package( Boost COMPONENTS unit_test_framework REQUIRED )
+if( JSON_SPIRIT_FUZZING )
+  # the fuzzer needs the Boost Locale library to filter valid UTF-8 strings
+  find_package( Boost COMPONENTS unit_test_framework locale REQUIRED )
+else()
+  find_package( Boost COMPONENTS unit_test_framework REQUIRED )
+endif()
+
 include_directories( . ${Boost_INCLUDE_DIRS} )
 
 file( GLOB SRC_FILES libs/json/src/*.cpp )
 add_library( json STATIC ${SRC_FILES} )
+if( JSON_SPIRIT_FUZZING )
+  # FUZZING USAGE:
+
+  # libFuzzer (requires Clang and its tooling library):
+  # cmake -DLLVM_ROOT=/path/to/llvm -DJSON_SPIRIT_FUZZING=ON ..;make
+  # libs/json/test/fuzzer -max_len=256 -jobs=2 /path/to/corpus
+
+  # AFL via Clang "fast" instrumentation
+  # cmake -DCMAKE_CXX_COMPILER=/path/to/afl/afl-clang-fast++ -DJSON_SPIRIT_FUZZING=ON ..;make
+  # /path/to/afl/afl-fuzz -i /path/to/corpus -o FINDINGS -m none -- libs/json/test/fuzzer
+
+  # AFL via g++
+  # cmake -DCMAKE_CXX_COMPILER=/path/to/afl/afl-g++ -DJSON_SPIRIT_FUZZING=ON ..;make
+  # /path/to/afl/afl-fuzz -i /path/to/corpus -o FINDINGS -m none -- libs/json/test/fuzzer
+
+  # create a version of the json library with the sanitizer enabled
+  # for use by the fuzzer executable in the test directory
+  add_library( json_fuzz STATIC ${SRC_FILES} )
+  set( FUZZ_TARGET_COMPILE_FLAGS "-fsanitize=${SANITIZER}" )
+  set( FUZZ_TARGET_LINK_FLAGS    "-fsanitize=${SANITIZER}" )
+  # depending on the compiler and sanitizer, we may need to
+  # add extra flags
+  if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
+    # are we using the special AFL instrumented compiler?
+    string(REGEX MATCH "afl-clang-fast\\+\\+$" AFL ${CMAKE_CXX_COMPILER})
+  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # or the gcc equivalent?
+    string(REGEX MATCH "afl-g\\+\\+$" AFL ${CMAKE_CXX_COMPILER})
+  else()
+    message( FATAL "Fuzzing only works with gcc or Clang" )
+  endif()
+
+  if( AFL )
+    if( SANITIZER EQUAL "address" )
+      # add "hardening options"
+      set( FUZZ_TARGET_COMPILE_FLAGS "${FUZZ_TARGET_COMPILE_FLAGS} -D_FORTIFY_SOURCE=2 -fstack-protector-all" )
+    elseif( SANITIZER EQUAL "memory" )
+      set( FUZZ_TARGET_COMPILE_FLAGS "${FUZZ_TARGET_COMPILE_FLAGS} -sanitize-memory-track-origins=2" )
+    endif()
+  elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
+    # assuming libFuzzer
+    set( FUZZ_TARGET_COMPILE_FLAGS "${FUZZ_TARGET_COMPILE_FLAGS} -fsanitize-coverage=edge" )
+    set( FUZZ_TARGET_LINK_FLAGS    "${FUZZ_TARGET_LINK_FLAGS}    -fsanitize-coverage=edge" )
+  endif()
+
+  if( WIN32 AND NOT AFL )
+    message( FATAL "libFuzzer does not work under Windows, for now" )
+  endif()
+
+  set_target_properties( json_fuzz PROPERTIES COMPILE_FLAGS ${FUZZ_TARGET_COMPILE_FLAGS}
+                                              LINK_FLAGS    ${FUZZ_TARGET_LINK_FLAGS} )
+
+endif()
 
 if(JSON_SPIRIT_DEBUG_PARSER)
   target_compile_definitions(

--- a/libs/json/test/CMakeLists.txt
+++ b/libs/json/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake build control file for json_spirit unit tests
-# Copyright (C) 2013 Jeff Trull <edaskel@att.net>
+# Copyright (C) 2013, 2015 Jeff Trull <edaskel@att.net>
 #
 #   Distributed under the Boost Software License, Version 1.0. (See accompanying
 #   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -32,7 +32,32 @@ endif()
 foreach( tname
     construct value_basic value_array value_object value_non_container get get_as parser_test )
   add_executable( ${tname} ${tname}.cpp )
-  target_link_libraries( ${tname} json ${Boost_LIBRARIES} )
+  target_link_libraries( ${tname} json ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
   add_test( ${tname} ${tname} )
 endforeach()
 
+# if fuzzing is enabled, produce the extra fuzzer target
+if( JSON_SPIRIT_FUZZING )
+  if( AFL )
+    add_executable( fuzzer fuzz_afl.cpp )
+  elseif( ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" ) AND LLVM_ROOT )
+    # Build the libFuzzer-based fuzzer
+    add_executable( fuzzer fuzz_lib.cpp )
+    set_target_properties( fuzzer PROPERTIES COMPILE_FLAGS "-fsanitize-coverage=edge"
+                                             LINK_FLAGS    "-fsanitize-coverage=edge" )
+
+    # and the library it depends on
+    file(GLOB LIBFUZZ_SOURCES ${LLVM_ROOT}/lib/Fuzzer/*.cpp)
+    include_directories( ${LLVM_ROOT}/lib/Fuzzer )
+    add_library( fuzz ${LIBFUZZ_SOURCES} )
+    target_link_libraries( fuzzer fuzz )
+
+  else()
+    message( FATAL "Don't know which fuzzer to build - afl compilers not in use and Clang+LLVM_ROOT not specified" )
+  endif()
+
+  target_link_libraries( fuzzer json_fuzz ${Boost_LOCALE_LIBRARY} )
+  set_target_properties( fuzzer PROPERTIES COMPILE_FLAGS ${FUZZ_TARGET_COMPILE_FLAGS}
+                                           LINK_FLAGS    ${FUZZ_TARGET_LINK_FLAGS} )
+
+endif()

--- a/libs/json/test/fuzz_afl.cpp
+++ b/libs/json/test/fuzz_afl.cpp
@@ -1,0 +1,82 @@
+/**
+ *  Copyright (C) 2015 Jeff Trull <edaskel@att.net>
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+// "handle one input" standalone program for AFL
+// very similar to the libFuzzer version
+
+#include <sstream>
+#include <string>
+#include <iostream>
+
+#include <boost/locale.hpp>
+
+#include "ciere/json/value.hpp"
+#include "ciere/json/io.hpp"
+
+int main() {
+   using namespace boost::locale::conv;
+   using namespace ciere;
+
+    // stream std::cin into a string
+    std::string s((std::istreambuf_iterator<char>(std::cin)),
+                  (std::istreambuf_iterator<char>()));
+
+   // reject inputs with non-ASCII characters outside of strings
+   for (auto sbeg = s.begin(); sbeg != s.end(); ++sbeg) {
+      if (*sbeg & 0x80) {
+         // bit 7 set -> non-ASCII
+         return 0;
+      }
+      // quoted strings can have non-ASCII if they are valid UTF-8
+      if (*sbeg == '"') {
+         // a string begins here
+         auto scur = sbeg + 1;
+         while ((scur != s.end()) && (*scur != '"')) {
+            if ((*scur == '\\') && ((scur+1) != s.end())) {
+               // next character is quoted; skip it
+               scur++;
+            }
+            scur++;
+         }
+         if (scur != s.end()) {
+            // we found a complete quoted string
+            std::string quoted_string(sbeg+1, scur);
+            try {
+               // throw if not a valid UTF-8 string:
+               std::wstring ws=to_utf<wchar_t>(quoted_string,"UTF-8",stop);
+            } catch (conversion_error) {
+               return 0;  // this is not an interesting string
+            }
+         } else {
+            // we arrived at the end of the string without finding a terminating double quote; reject
+            return 0;
+         }
+         sbeg = scur;   // move forward
+      }
+   }
+
+   // this input is valid. Let's try using it
+   try {
+      auto v = json::construct(s);
+      // We had valid input and we constructed a value.  Let's see what we got:
+      std::stringstream ss;
+      try {
+         ss << v;   // activate recursive visitors etc.
+      } catch (std::out_of_range) {
+         // most likely an invalid Unicode string etc. (thrown by UTF converter)
+         return 0;
+      }
+      if (!s.empty()) {
+         assert(ss.str().size() > 0);   // use the result to avoid getting optimized out
+      }
+   } catch (json::parse_error e) {
+      // this is fine for fuzzing purposes
+      return 0;
+   }
+
+   return 0;   // the only valid code, for now
+}

--- a/libs/json/test/fuzz_lib.cpp
+++ b/libs/json/test/fuzz_lib.cpp
@@ -1,0 +1,84 @@
+/**
+ *  Copyright (C) 2015 Jeff Trull <edaskel@att.net>
+ *
+ *  Distributed under the Boost Software License, Version 1.0. (See accompanying
+ *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+// Use the LLVM fuzzing library to try to find bugs
+
+#include <sstream>
+#include <string>
+#include <iostream>
+
+#include <boost/locale.hpp>
+
+#include "ciere/json/value.hpp"
+#include "ciere/json/io.hpp"
+
+// the one function you need to provide
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *data, unsigned long size) {
+
+   using namespace boost::locale::conv;
+   using namespace ciere;
+
+   std::string s((const char*)data, size);
+
+   // reject inputs with non-ASCII characters outside of strings
+   for (auto sbeg = s.begin(); sbeg != s.end(); ++sbeg) {
+      if (*sbeg & 0x80) {
+         // bit 7 set -> non-ASCII
+         return 0;
+      }
+      // quoted strings can have non-ASCII if they are valid UTF-8
+      if (*sbeg == '"') {
+         // a string begins here
+         auto scur = sbeg + 1;
+         while ((scur != s.end()) && (*scur != '"')) {
+            if ((*scur == '\\') && ((scur+1) != s.end())) {
+               // next character is quoted; skip it
+               scur++;
+            }
+            scur++;
+         }
+         if (scur != s.end()) {
+            // we found a complete quoted string
+            std::string quoted_string(sbeg+1, scur);
+            try {
+               // throw if not a valid UTF-8 string:
+               auto ws=to_utf<wchar_t>(quoted_string,"UTF-8",stop);
+            } catch (conversion_error) {
+               return 0;  // this is not an interesting string
+            }
+         } else {
+            // we arrived at the end of the string without finding a terminating double quote; reject
+            return 0;
+         }
+         sbeg = scur;   // move forward
+      }
+   }
+
+   // this input is valid. Let's try using it
+   try {
+      auto v = json::construct(s);
+      // We had valid input and we constructed a value.  Let's see what we got:
+      std::stringstream ss;
+      try {
+         ss << v;   // activate recursive visitors etc.
+      } catch (std::out_of_range) {
+         // most likely an invalid Unicode string etc. (thrown by UTF converter)
+         return 0;
+      }
+      if (size > 0) {
+         assert(ss.str().size() > 0);   // use the result to avoid getting optimized out
+      }
+   } catch (json::parse_error e) {
+      // this is fine for fuzzing purposes
+      return 0;
+   }
+
+   return 0;   // the only valid code, for now
+}
+
+// with non-ASCII back on we have this: "[nan(a1-:\"),\".\"\334\265a\""
+// test again when assert is fixed


### PR DESCRIPTION
This PR implements fuzzing via the LLVM libFuzzer (under Clang) and AFL (under either Clang or gcc).