### PR TITLE
Prevent some compiler warnings on Visual Studio 2015

### DIFF
--- a/ciere/json/detail/value_impl.hpp
+++ b/ciere/json/detail/value_impl.hpp
@@ -45,7 +45,7 @@ namespace ciere { namespace json
          static R apply( T const & v
                        , typename boost::enable_if<boost::is_convertible<R,T> >::type* /*dummy*/=0 )
          {
-            return v;
+            return static_cast<R>(v);
          }
 
 
@@ -107,7 +107,7 @@ namespace ciere { namespace json
          static bool_t apply( T const & v
                             , typename boost::enable_if<boost::is_convertible<bool_t,T> >::type* /*dummy*/=0 )
          {
-            return v;
+            return v != 0;
          }
 
          static bool_t apply( string_t const & v )

--- a/libs/json/test/get.cpp
+++ b/libs/json/test/get.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(basic_get)
 
    {
       value = 42;
-      int tmp = value.get<json::int_t>();
+      int64_t tmp = value.get<json::int_t>();
       BOOST_CHECK_EQUAL(tmp, 42);
 
       BOOST_CHECK_THROW(value.get<json::float_t>(), boost::bad_get /*json::get_as_error*/ );

--- a/libs/json/test/get_as.cpp
+++ b/libs/json/test/get_as.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(basic_get_as)
 
    {
       value = 42;
-      int tmp = value.get_as<json::int_t>();
+      int64_t tmp = value.get_as<json::int_t>();
       BOOST_CHECK_EQUAL(tmp, 42);
       std::string tmp_str = value.get_as<json::string_t>();
       BOOST_CHECK_EQUAL(tmp_str, "42");
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(basic_get_as)
       BOOST_CHECK_EQUAL(tmp, 42.5);
       std::string tmp_str = value.get_as<json::string_t>();
       BOOST_CHECK_EQUAL(tmp_str, "42.5");
-      int tmp_int = value.get_as<json::int_t>();
+      int64_t tmp_int = value.get_as<json::int_t>();
       BOOST_CHECK_EQUAL(tmp_int, 42);
    }
 

--- a/libs/json/test/value_non_container.cpp
+++ b/libs/json/test/value_non_container.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(float_test)
    v1 = d1;
    BOOST_CHECK_EQUAL(v1, v3);
 
-   float f1 = 123.4567;
+   float f1 = 123.4567f;
    json::value v4(f1);
    BOOST_CHECK_EQUAL(v4.type(), json::double_type);
    BOOST_CHECK_EQUAL(v4, f1);


### PR DESCRIPTION
Hi,

Visual Studio 2015 emits warnings C4244 and C4800 for "possible loss of data" and "forcing value to true or false" during compilation. Here is a commit to prevent these warnings from appearing.